### PR TITLE
Add promise caching and a prev() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ A generator that makes requests to Pixabay and returns a promise for each.
 #### `ResultList.next()`
 Returns a promise for the next page of results. Normally begins with the first page, but the initial page can be set by setting the `page` key in the `options` passed into `RequestFactory.resultList({options})`.
 
+#### `ResultList.previous()`
+Returns a promose for the previous page of results. Will throw an error when requesting pages numbered <= 1;
+
 ### Pixabay Results
 By default, a response will be in the following form:
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "phantomjs": "^1.9.17",
     "promisehelpers": "0.0.3",
     "q": "^1.3.0",
+    "sinon": "^1.15.3",
+    "sinon-chai": "^2.8.0",
     "superagent": "^1.2.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,16 +35,12 @@
     "mockagent": "^0.1.4",
     "phantomjs": "^1.9.17",
     "promisehelpers": "0.0.3",
-    "q": "^1.3.0",
     "sinon": "^1.15.3",
-    "sinon-chai": "^2.8.0",
-    "superagent": "^1.2.0"
-  },
-  "peerDependencies": {
-    "q": ">= 1 < 2",
-    "superagent": ">= 1 < 2"
+    "sinon-chai": "^2.8.0"
   },
   "dependencies": {
-    "lodash.assign": "^3.2.0"
+    "lodash.assign": "^3.2.0",
+    "q": "^1.4.1",
+    "superagent": "^1.2.0"
   }
 }

--- a/src/result-list.js
+++ b/src/result-list.js
@@ -24,14 +24,15 @@ ResultList.prototype.next = function() {
 
   this._retriever.query({page: this._page});
 
-  var promise = this._requestPromises[this._page] ?
-    this._requestPromises[this._page] : this._get();
+  if (this._requestPromises[this._page]) {
+    return this._requestPromises[this._page];
+  }
 
-  return promise;
+  return this._get();
 };
 
-ResultList.prototype.prev = function() {
-  if (this._page === 1) {
+ResultList.prototype.previous = function() {
+  if (this._page <= 1) {
     throw new Error('There is no previous page');
   }
 

--- a/src/result-list.js
+++ b/src/result-list.js
@@ -12,22 +12,48 @@ function ResultList(retriever, options) {
   this._retriever = retriever;
   this._onFailure = options.onFailure;
   this._onSuccess = options.onSuccess;
-  this._page = options.page || 1;
+  this._page = options.page ? options.page - 1 : 0;
   this._perPage = options.perPage || 20;
+  this._requestPromises = [];
+
+  this._retriever.query({per_page: this._perPage});
 }
 
 ResultList.prototype.next = function() {
-  this._retriever.query({page: this._page, per_page: this._perPage});
   this._page += 1;
+
+  this._retriever.query({page: this._page});
+
+  var promise = this._requestPromises[this._page] ?
+    this._requestPromises[this._page] : this._get();
+
+  return promise;
+};
+
+ResultList.prototype.prev = function() {
+  if (this._page === 1) {
+    throw new Error('There is no previous page');
+  }
+
+  this._page -= 1;
+
+  if (this._requestPromises[this._page]) {
+    return this._requestPromises[this._page];
+  }
+
+  this._retriever.query({page: this._page});
+
   return this._get();
 };
 
 ResultList.prototype._get = function() {
-  var page = this._page - 1;
-  return this._retriever
+  var promise =  this._retriever
     .get()
-    .then(this._handleSuccess.bind(this, page, this._perPage))
-    .fail(this._handleFailure.bind(this, page, this._perPage));
+    .then(this._handleSuccess.bind(this, this._page, this._perPage))
+    .fail(this._handleFailure.bind(this, this._page, this._perPage));
+
+  this._requestPromises[this._page] = promise;
+  return promise;
 };
 
 ResultList.prototype._handleSuccess = function(page, perPage, res) {

--- a/test/pixabay-spec.js
+++ b/test/pixabay-spec.js
@@ -186,10 +186,10 @@ describe('pixabayjs', function() {
       });
     });
 
-    describe('prev() on page 1', function() {
+    describe('previous() on page 1', function() {
       it('throws an error when there is no previous page', function() {
         var test = function() {
-          resultList.prev();
+          resultList.previous();
         };
 
         expect(test).to.throw('There is no previous page');
@@ -212,7 +212,7 @@ describe('pixabayjs', function() {
       });
     });
 
-    describe('prev() on page 2', function() {
+    describe('previous() on page 2', function() {
       var response = {};
       var _get;
 
@@ -220,7 +220,7 @@ describe('pixabayjs', function() {
         _get = sinon.spy(ResultList.prototype, '_get');
 
         resultList
-          .prev()
+          .previous()
           .then(wrap(response, 'data'))
           .done(notify(done));
       });

--- a/test/pixabay-spec.js
+++ b/test/pixabay-spec.js
@@ -7,6 +7,8 @@ var pixabay = require('../src/index');
 var promiseHelpers = require('promisehelpers');
 var range = require('lodash.range');
 var ResultList = require('../src/result-list');
+var sinon = require('sinon');
+var sinonChai = require('sinon-chai');
 var superagent = require('superagent');
 var url = require('url');
 
@@ -15,7 +17,7 @@ var wrap = promiseHelpers.wrap;
 
 var expect = chai.expect;
 chai.use(chaiAsPromised);
-chai.should();
+chai.use(sinonChai);
 
 var username = 'username';
 var key = 'key';
@@ -125,14 +127,11 @@ describe('pixabayjs', function() {
   });
 
   describe('ResultList', function() {
-    var response1 = {};
-    var response2 = {};
-    var response3 = {};
     var requestFactory = {};
-    var resultList = {};
+    var resultList;
     var query;
 
-    before(function(done) {
+    before(function() {
       mockResponse();
 
       query = {
@@ -148,72 +147,141 @@ describe('pixabayjs', function() {
         .query(query)
         .search(['dogs', 'puppies'])
         .resultList();
-
-      resultList
-        .next()
-        .then(wrap(response1, 'data'))
-        .done(notify(done));
     });
 
     after(function() {
       mockagent.releaseTarget();
     });
 
-    describe('first request', function() {
-      it('receives the first page', function() {
-        expect(response1.data.page).to.equal(1);
-      });
+    describe('initial request for page 1', function() {
+      var response = {};
 
-      it('receives the hits', function() {
-        expect(response1.data.hits).to.be.length(20);
-      });
-
-      it('receives the totalHits', function() {
-        expect(response1.data.totalHits).to.equal(25);
-      });
-
-      it('receives the totalPages', function() {
-        expect(response1.data.totalPages).to.equal(2);
-      });
-
-      it('receives a null error', function() {
-        expect(response1.data.error).to.be.null;
-      });
-    });
-
-    describe('second request', function() {
       before(function(done) {
         resultList
           .next()
-          .then(wrap(response2, 'data'))
+          .then(wrap(response, 'data'))
+          .done(notify(done));
+      });
+
+      it('receives the first page', function() {
+        expect(response.data.page).to.equal(1);
+      });
+
+      it('receives the hits', function() {
+        expect(response.data.hits).to.be.length(20);
+      });
+
+      it('receives the totalHits', function() {
+        expect(response.data.totalHits).to.equal(25);
+      });
+
+      it('receives the totalPages', function() {
+        expect(response.data.totalPages).to.equal(2);
+      });
+
+      it('receives a null error', function() {
+        expect(response.data.error).to.be.null;
+      });
+    });
+
+    describe('prev() on page 1', function() {
+      it('throws an error when there is no previous page', function() {
+        var test = function() {
+          resultList.prev();
+        };
+
+        expect(test).to.throw('There is no previous page');
+      });
+    });
+
+    describe('next() on page 1', function() {
+      var response = {};
+
+      before(function(done) {
+        resultList
+          .next()
+          .then(wrap(response, 'data'))
           .done(notify(done));
       });
 
       it('receives the next set of hits', function() {
-        expect(response2.data.hits).to.be.length(5);
-        expect(response2.data.page).to.equal(2);
+        expect(response.data.hits).to.be.length(5);
+        expect(response.data.page).to.equal(2);
       });
     });
 
-    describe('third request', function() {
+    describe('prev() on page 2', function() {
+      var response = {};
+      var _get;
+
+      before(function(done) {
+        _get = sinon.spy(ResultList.prototype, '_get');
+
+        resultList
+          .prev()
+          .then(wrap(response, 'data'))
+          .done(notify(done));
+      });
+
+      after(function() {
+        _get.restore();
+      });
+
+      it('receives the page 1 response', function() {
+        expect(response.data.page).to.equal(1);
+      });
+
+      it('did not make a request', function() {
+        expect(_get).to.not.be.called;
+      });
+    });
+
+    describe('second next() on page 1', function() {
+      var response = {};
+      var _get;
+
+      before(function(done) {
+        _get = sinon.spy(ResultList.prototype, '_get');
+        resultList
+          .next()
+          .then(wrap(response, 'data'))
+          .done(notify(done));
+      });
+
+      after(function() {
+        _get.restore();
+      });
+
+      it('receives the page 2 response', function() {
+        expect(response.data.page).to.equal(2);
+      });
+
+      it('does not make a request', function() {
+        expect(_get).to.not.be.called;
+      });
+    });
+
+    describe('next() on page 2', function() {
+      var response = {};
+
       before(function(done) {
         resultList
           .next()
-          .then(wrap(response3, 'data'))
+          .then(wrap(response, 'data'))
           .done(notify(done));
       });
 
       it('reports the page requested', function() {
-        expect(response3.data.page).to.equal(3);
+        expect(response.data.page).to.equal(3);
       });
 
       it('returns an empty array of hits', function() {
-        expect(response3.data.hits).to.be.empty;
+        expect(response.data.hits).to.be.empty;
       });
 
       it('returns an error', function() {
         var errorRgx = /ERROR: "page"\/"per_page" is out of valid range\./;
-        expect(response3.data.error).to.match(errorRgx);
+        expect(response.data.error).to.match(errorRgx);
       });
     });
   });


### PR DESCRIPTION
Promises are now cached with this PR.

Adds a `prev` function that will return the previous response if it exists, or make it if it doesn't, such as in the case the ResultList was set to request a page > 2.
