### PR TITLE
rename _internal to requiredDefaults for clarity of purpose

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,6 @@ var ResultList = require('./result-list');
 var requiredDefaults = {
   page: 1,
   per_page: 20,
-  safesearch: true,
   url: 'https://pixabay.com/api'
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@
 var assign = require('lodash.assign');
 var ResultList = require('./result-list');
 
-var _internal = {
+var requiredDefaults = {
   page: 1,
   per_page: 20,
   safesearch: true,
@@ -20,8 +20,8 @@ var pixabayjs = {
     this._auth.key = key;
   },
 
-  resultList: function(search, options, onSuccess, onFailure) {
-    var config = assign({}, _internal, this.defaults, this._auth, options);
+  resultList: function(search, opts, onSuccess, onFailure) {
+    var config = assign({}, requiredDefaults, this.defaults, this._auth, opts);
     return new ResultList(search, config, onSuccess, onFailure);
   }
 };


### PR DESCRIPTION
remove `safesearch` from `requiredDefaults`, as neither the pixabay API nor this client need it to function
