### PR TITLE
Update API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,8 +14,7 @@ const pixabayjs = {
 
   defaults: {},
 
-  authenticate: function(username, key) {
-    this._auth.username = username;
+  authenticate: function(key) {
     this._auth.key = key;
   },
 

--- a/test/pixabay-spec.js
+++ b/test/pixabay-spec.js
@@ -9,7 +9,6 @@ const {expect} = chai;
 
 chai.use(chaiAsPromised);
 
-const username = 'username';
 const key = 'key';
 
 describe('Pixabayjs', function() {
@@ -25,9 +24,8 @@ describe('Pixabayjs', function() {
   });
 
   describe('authenticate', function() {
-    it('sets the client\'s username and key', function() {
-      client.authenticate(username, key);
-      expect(client._auth.username).to.equal(username);
+    it('sets the client\'s key', function() {
+      client.authenticate(key);
       expect(client._auth.key).to.equal(key);
     });
   });

--- a/test/result-list-spec.js
+++ b/test/result-list-spec.js
@@ -18,11 +18,7 @@ const {notify, wrap} = require('promisehelpers');
 chai.use(chaiAsPromised);
 chai.use(sinonChai);
 
-const username = 'username';
-const key = 'key';
 const pixabayUrl = 'https://pixabay.com/api';
-
-pixabay.authenticate(username, key);
 
 const mockResponse = function() {
   mockagent.target(superagent);


### PR DESCRIPTION
Fixes https://github.com/yola/pixabayjs/issues/32
- Remove `user` parameter.
- We already were defaulting to HTTPS. Should it be required since HTTP is no longer supported?
